### PR TITLE
Fix base URL for GitHub Pages deployment

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -11,9 +11,10 @@ let moonInstance: ReturnType<typeof moonbitMode.init> | null = null;
 
 async function ensureMoonInit() {
   if (!moonInitialized) {
+    const base = import.meta.env.BASE_URL;
     moonInstance = moonbitMode.init({
-      onigWasmUrl: '/onig.wasm',
-      mooncWorkerFactory: () => new Worker('/moonc-worker.js')
+      onigWasmUrl: `${base}onig.wasm`,
+      mooncWorkerFactory: () => new Worker(`${base}moonc-worker.js`)
     });
     moonInitialized = true;
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import preact from '@preact/preset-vite'
 
-export default defineConfig({
-  base: '/moonbit-online/',
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/moonbit-online/' : '/',
   plugins: [preact()],
   worker: {
     format: 'es'
@@ -10,4 +10,4 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['@moonbit/moonc-worker']
   }
-})
+}))


### PR DESCRIPTION
## 問題
GitHub Pagesへのデプロイ時に、ローカルとbaseが異なるため、wasmやjsファイルが正しく読み込まれない問題がありました。

## 修正内容
- **vite.config.ts**: 開発時は `/`、ビルド時は `/moonbit-online/` を使用するように動的に設定
- **src/compiler.ts**: `import.meta.env.BASE_URL` を使用してassetパスを動的に解決

## 動作
- ローカル開発 (`npm run dev`): `/onig.wasm`, `/moonc-worker.js` から読み込み
- GitHub Pages (`npm run build`): `/moonbit-online/onig.wasm`, `/moonbit-online/moonc-worker.js` から読み込み