### PR TITLE
Add Comprehensive Demo sample and decompose SAMPLE_CODES into src/sample_codes/*.mbt

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import { useState, useEffect } from 'preact/hooks';
 import { MoonbitCompiler } from './compiler';
 import { LineNumberEditor } from './LineNumberEditor';
@@ -6,50 +7,25 @@ declare const __MOONPAD_VERSION__: string;
 
 const compiler = new MoonbitCompiler();
 
-const SAMPLE_CODES = {
-  'Hello': `fn main {
-  println("Hello, MoonBit!")
-  let x = 42
-  println("The answer is \\{x}")
-}`,
-  'Multiple Files': `fn main {
-  hello()
-  let result = add(10, 20)
-  println("10 + 20 = \\{result}")
-}
--- lib.mbt --
-pub fn hello() -> Unit {
-  println("Hello from lib.mbt!")
-}
+// Load sample codes from src/sample_codes/*.mbt at build time via Vite glob import.
+// File naming: NN_snake_case.mbt → display name (strip numeric prefix, titlecase).
+const _rawSamples = import.meta.glob('./sample_codes/*.mbt', { as: 'raw', eager: true });
+const SAMPLE_CODES: Record<string, string> = Object.fromEntries(
+  Object.entries(_rawSamples)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([path, content]) => {
+      const name = path
+        .replace('./sample_codes/', '')
+        .replace('.mbt', '')
+        .replace(/^\d+_/, '')
+        .split('_')
+        .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+      return [name, content as string];
+    })
+);
 
-pub fn add(a : Int, b : Int) -> Int {
-  a + b
-}`,
-  'With Package Import': `fn main {
-  // Using @moonbitlang/core/hashmap package
-  let map = @hashmap.from_array([("a", 1), ("b", 2), ("c", 3)])
-  println("Initial map: \\{map}")
-  
-  // Remove an entry
-  map.remove("a") |> ignore
-  println("After removing 'a': \\{map}")
-  
-  // Add new entries
-  map.set("d", 4)
-  map.set("e", 5)
-  println("After adding 'd' and 'e': \\{map}")
-  
-  // Get a value
-  match map.get("b") {
-    Some(v) => println("Value of 'b': \\{v}")
-    None => println("Key 'b' not found")
-  }
-  
-  println("Map size: \\{map.size()}")
-}`
-};
-
-const DEFAULT_CODE = SAMPLE_CODES['Hello'];
+const DEFAULT_CODE = Object.values(SAMPLE_CODES)[0];
 
 function parseMultipleFiles(source: string): Array<[string, string]> {
   const files: Array<[string, string]> = [];
@@ -100,7 +76,7 @@ export function App() {
   const [isRunning, setIsRunning] = useState(false);
   const [isFormatting, setIsFormatting] = useState(false);
   const [isError, setIsError] = useState(false);
-  const [selectedSample, setSelectedSample] = useState<keyof typeof SAMPLE_CODES>('Hello');
+  const [selectedSample, setSelectedSample] = useState<string>(Object.keys(SAMPLE_CODES)[0]);
 
   // Load code from URL hash on mount
   useEffect(() => {
@@ -148,7 +124,7 @@ export function App() {
   };
 
   const handleSampleChange = (e: Event) => {
-    const value = (e.target as HTMLSelectElement).value as keyof typeof SAMPLE_CODES;
+    const value = (e.target as HTMLSelectElement).value;
     setSelectedSample(value);
     setCode(SAMPLE_CODES[value]);
   };

--- a/src/sample_codes/01_hello.mbt
+++ b/src/sample_codes/01_hello.mbt
@@ -1,0 +1,5 @@
+fn main {
+  println("Hello, MoonBit!")
+  let x = 42
+  println("The answer is \{x}")
+}

--- a/src/sample_codes/02_multiple_files.mbt
+++ b/src/sample_codes/02_multiple_files.mbt
@@ -1,0 +1,13 @@
+fn main {
+  hello()
+  let result = add(10, 20)
+  println("10 + 20 = \{result}")
+}
+-- lib.mbt --
+pub fn hello() -> Unit {
+  println("Hello from lib.mbt!")
+}
+
+pub fn add(a : Int, b : Int) -> Int {
+  a + b
+}

--- a/src/sample_codes/03_with_package_import.mbt
+++ b/src/sample_codes/03_with_package_import.mbt
@@ -1,0 +1,22 @@
+fn main {
+  // Using @moonbitlang/core/hashmap package
+  let map = @hashmap.from_array([("a", 1), ("b", 2), ("c", 3)])
+  println("Initial map: \{map}")
+  
+  // Remove an entry
+  map.remove("a") |> ignore
+  println("After removing 'a': \{map}")
+  
+  // Add new entries
+  map.set("d", 4)
+  map.set("e", 5)
+  println("After adding 'd' and 'e': \{map}")
+  
+  // Get a value
+  match map.get("b") {
+    Some(v) => println("Value of 'b': \{v}")
+    None => println("Key 'b' not found")
+  }
+  
+  println("Map size: \{map.length()}")
+}

--- a/src/sample_codes/04_comprehensive_demo.mbt
+++ b/src/sample_codes/04_comprehensive_demo.mbt
@@ -1,0 +1,320 @@
+// ============================================
+// MoonBit Comprehensive Feature Demo
+// Standard Library Only
+// ============================================
+
+// ----------------------------------------
+// 1. Error Types (suberror)
+// ----------------------------------------
+suberror EvalError {
+  DivByZero
+  UnknownVariable(String)
+}
+
+// ----------------------------------------
+// 2. Algebraic Data Types (Enum with payloads)
+// ----------------------------------------
+enum Expression {
+  Number(Double)
+  Variable(String)
+  Add(Expression, Expression)
+  Mul(Expression, Expression)
+  Div(Expression, Expression)
+  Let(String, Expression, Expression) // let x = e1 in e2
+}
+
+// ----------------------------------------
+// 3. Structs with mut fields
+// ----------------------------------------
+struct Environment {
+  bindings : Map[String, Double]
+  mut eval_count : Int
+}
+
+struct Stats {
+  sum : Double
+  mean : Double
+  samples : Array[Double]
+}
+
+// ----------------------------------------
+// 4. Traits (Type Classes)
+// ----------------------------------------
+trait Show {
+  to_string(Self) -> String
+}
+
+// ----------------------------------------
+// 5. Methods and Trait Implementations
+// ----------------------------------------
+
+// Environment methods
+fn Environment::new() -> Environment {
+  { bindings: Map::new(), eval_count: 0 }
+}
+
+fn Environment::extend(self : Environment, name : String, value : Double) -> Environment {
+  let new_bindings = self.bindings.copy()
+  new_bindings.set(name, value)
+  { bindings: new_bindings, eval_count: self.eval_count }
+}
+
+fn Environment::lookup(self : Environment, name : String) -> Double? {
+  self.eval_count = self.eval_count + 1
+  self.bindings.get(name)
+}
+
+// Show trait for Expression
+impl Show for Expression with to_string(self) {
+  match self {
+    Number(n) => n.to_string()
+    Variable(name) => name
+    Add(e1, e2) => "(\{e1.to_string()} + \{e2.to_string()})"
+    Mul(e1, e2) => "(\{e1.to_string()} * \{e2.to_string()})"
+    Div(e1, e2) => "(\{e1.to_string()} / \{e2.to_string()})"
+    Let(name, e1, e2) => "(let \{name} = \{e1.to_string()} in \{e2.to_string()})"
+  }
+}
+
+// Show for Stats
+impl Show for Stats with to_string(self) {
+  "Stats(mean: \{self.mean}, sum: \{self.sum}, n: \{self.samples.length()})"
+}
+
+// ----------------------------------------
+// 6. Pattern Matching & Error Handling
+// ----------------------------------------
+fn Expression::eval(self : Expression, env : Environment) -> Double raise EvalError {
+  match self {
+    Number(n) => n
+    Variable(name) => {
+      match env.lookup(name) {
+        Some(v) => v
+        None => raise EvalError::UnknownVariable(name)
+      }
+    }
+    Add(e1, e2) => e1.eval(env) + e2.eval(env)
+    Mul(e1, e2) => e1.eval(env) * e2.eval(env)
+    Div(e1, e2) => {
+      let divisor = e2.eval(env)
+      if divisor == 0.0 {
+        raise EvalError::DivByZero
+      }
+      e1.eval(env) / divisor
+    }
+    Let(name, e1, e2) => {
+      let val = e1.eval(env)
+      let new_env = env.extend(name, val)
+      e2.eval(new_env)
+    }
+  }
+}
+
+// ----------------------------------------
+// 7. Generic Functions & Named Parameters
+// ----------------------------------------
+fn[T] option_or_default(opt : T?, default~ : T) -> T {
+  match opt {
+    Some(v) => v
+    None => default
+  }
+}
+
+fn[T, U, E] result_map(result : Result[T, E], f : (T) -> U) -> Result[U, E] {
+  match result {
+    Ok(v) => Ok(f(v))
+    Err(e) => Err(e)
+  }
+}
+
+// Named parameters with defaults
+fn create_stats(
+  data : Array[Double],
+  include_mean~ : Bool = true
+) -> Stats {
+  let n = data.length()
+  let sum = if n == 0 {
+    0.0
+  } else {
+    // Loop expression with accumulator
+    loop (0, 0.0) {
+      (i, acc) => {
+        if i >= n {
+          break acc // break returns value from loop
+        }
+        continue (i + 1, acc + data[i])
+      }
+    }
+  }
+  let mean = if include_mean && n > 0 {
+    sum / n.to_double()
+  } else {
+    0.0
+  }
+  { sum, mean, samples: data }
+}
+
+// ----------------------------------------
+// 8. Array Operations & Pattern Matching
+// ----------------------------------------
+fn analyze_list(lst : Array[Int]) -> String {
+  match lst {
+    [] => "Empty list"
+    [x] => "Single element: \{x}"
+    [first, second, .. rest] => {
+      let len = lst.length()
+      let rest_sum = loop (0, 0) {
+        (i, acc) => {
+          if i >= rest.length() {
+            break acc
+          }
+          continue (i + 1, acc + rest[i])
+        }
+      }
+      "First two: \{first}, \{second}; Total length: \{len}; Rest sum: \{rest_sum}"
+    }
+  }
+}
+
+fn array_sum(arr : Array[Int]) -> Int {
+  // For loop as expression
+  for i = 0, acc = 0; i < arr.length(); i = i + 1 {
+    continue i + 1, acc + arr[i]
+  } nobreak {
+    acc
+  }
+}
+
+// ----------------------------------------
+// 9. String Processing with Views
+// ----------------------------------------
+fn is_palindrome(s : String) -> Bool {
+  let view = s.view()
+  fn check(v : StringView) -> Bool {
+    match v {
+      [] | [_] => true
+      [first, .. rest, last] => {
+        if first == last {
+          check(rest)
+        } else {
+          false
+        }
+      }
+    }
+  }
+  check(view)
+}
+
+// ----------------------------------------
+// 10. Main Function - Demonstration
+// ----------------------------------------
+fn main {
+  println("=== MoonBit Feature Showcase ===\n")
+
+  // -- Variable bindings --
+  let immutable_val = 42
+  let mut mutable_val = 0
+  mutable_val = immutable_val / 2
+  println("Immutable: \{immutable_val}, Mutable: \{mutable_val}")
+
+  // -- Expression evaluation with error handling --
+  let env = Environment::new()
+  let expr = Let("x", Number(10.0),
+    Add(
+      Variable("x"),
+      Mul(Number(2.0), Div(Number(6.0), Number(2.0)))
+    )
+  )
+  println("\nExpression: \{expr.to_string()}")
+  try {
+    let result = expr.eval(env)
+    println("Evaluated to: \{result}")
+    println("Total variable lookups: \{env.eval_count}")
+  } catch {
+    EvalError::DivByZero => println("Error: Division by zero!")
+    EvalError::UnknownVariable(name) => println("Error: Unknown variable '\{name}'")
+  }
+
+  // -- Loop expressions --
+  println("\n-- Loop Expressions --")
+  let factorial_5 = loop (5, 1) {
+    (n, acc) => {
+      if n <= 1 {
+        break acc
+      }
+      continue (n - 1, acc * n)
+    }
+  }
+  println("5! = \{factorial_5}")
+
+  // -- For loop as expression --
+  let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  let sum_even = for i = 0, sum = 0; i < numbers.length(); i = i + 1 {
+    if numbers[i] % 2 == 0 {
+      continue i + 1, sum + numbers[i]
+    } else {
+      continue i + 1, sum
+    }
+  } nobreak {
+    sum
+  }
+  println("Sum of even numbers: \{sum_even}")
+
+  // -- While loop with break value --
+  let mut count = 0
+  let found = while count < 100 {
+    count = count + 7
+    if count > 50 {
+      break "Found at \{count}"
+    }
+  } nobreak {
+    "Not found"
+  }
+  println("While result: \{found}")
+
+  // -- Pattern matching on arrays --
+  println("\n-- Array Patterns --")
+  let test_list = [1, 2, 3, 4, 5]
+  println(analyze_list(test_list))
+
+  // -- Option and Result types --
+  println("\n-- Optional Values --")
+  let maybe_value : Int? = Some(42)
+  let defaulted = option_or_default(maybe_value, default=0)
+  println("Option value: \{defaulted}")
+
+  let division_result : Result[Double, EvalError] = try? {
+    Expression::Div(Number(10.0), Number(0.0)).eval(Environment::new())
+  }
+  match division_result {
+    Ok(v) => println("Division succeeded: \{v}")
+    Err(_) => println("Division failed as expected")
+  }
+
+  // -- Statistics with named parameters --
+  println("\n-- Statistics --")
+  let data = [2.5, 3.5, 4.5, 5.5, 6.5]
+  let stats = create_stats(data, include_mean=true)
+  println(stats.to_string())
+
+  // -- String view pattern matching --
+  println("\n-- String Processing --")
+  let words = ["radar", "moonbit", "level", "hello", "世界界世"]
+  for word in words {
+    if is_palindrome(word) {
+      println("'\{word}' is a palindrome")
+    }
+  }
+
+  // -- Map operations --
+  println("\n-- Map Operations --")
+  let map : Map[String, Int] = Map::new()
+  map.set("one", 1)
+  map.set("two", 2)
+  map.set("three", 3)
+  for key, value in map {
+    println("\{key} => \{value}")
+  }
+
+  println("\n=== End of Demo ===")
+}

--- a/test/compiler-node.test.mjs
+++ b/test/compiler-node.test.mjs
@@ -399,3 +399,96 @@ pub fn hello() -> Unit {
     worker.terminate();
   }
 });
+
+// ---------------------------------------------------------------------------
+// Sample code tests — compile and run every file in src/sample_codes/
+// ---------------------------------------------------------------------------
+
+import { readdirSync, readFileSync } from 'fs';
+
+/**
+ * Parse a multi-file MoonBit source string (using `-- filename --` separators)
+ * into an array of [filename, content] tuples, matching app.tsx parseMultipleFiles.
+ */
+function parseSampleFiles(source) {
+  const files = [];
+  const lines = source.split('\n');
+  let currentFile = 'main.mbt';
+  let currentContent = [];
+  for (const line of lines) {
+    const match = line.match(/^--\s+(.+?)\s+--$/);
+    if (match) {
+      if (currentContent.length > 0 || files.length === 0) {
+        files.push([currentFile, currentContent.join('\n')]);
+      }
+      currentFile = match[1].trim();
+      currentContent = [];
+    } else {
+      currentContent.push(line);
+    }
+  }
+  if (currentContent.length > 0 || files.length === 0) {
+    files.push([currentFile, currentContent.join('\n')]);
+  }
+  return files;
+}
+
+const samplesDir = join(__dir, '../src/sample_codes');
+const sampleFiles = readdirSync(samplesDir).filter(f => f.endsWith('.mbt')).sort();
+
+/** Derive the display name from a sample filename (matches Vite glob logic in app.tsx). */
+function sampleDisplayName(filename) {
+  return filename
+    .replace('.mbt', '')
+    .replace(/^\d+_/, '')
+    .split('_')
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+// Expected output snippets for each sample (keyed by display name).
+const EXPECTED_OUTPUTS = {
+  'Hello': 'Hello, MoonBit!',
+  'Multiple Files': 'Hello from lib.mbt!',
+  'With Package Import': "Value of 'b': 2",
+  'Comprehensive Demo': '=== MoonBit Feature Showcase ===',
+};
+
+for (const sampleFile of sampleFiles) {
+  const displayName = sampleDisplayName(sampleFile);
+  const source = readFileSync(join(samplesDir, sampleFile), 'utf-8');
+  const mbtFiles = parseSampleFiles(source);
+
+  test(`sample: ${displayName} — compiles without errors`, async () => {
+    const worker = new Worker(join(__dir, 'worker-bootstrap.cjs'));
+    try {
+      const buildResult = await buildPackage(worker, mbtFiles);
+      // Filter out warning-level diagnostics; only fail on errors
+      const errors = buildResult.diagnostics.filter(d => {
+        try { return JSON.parse(d).level === 'error'; } catch { return true; }
+      });
+      assert.deepEqual(errors, [], `${displayName}: no compilation errors`);
+    } finally {
+      worker.terminate();
+    }
+  });
+
+  test(`sample: ${displayName} — runs and produces expected output`, async () => {
+    const worker = new Worker(join(__dir, 'worker-bootstrap.cjs'));
+    try {
+      const buildResult = await buildPackage(worker, mbtFiles);
+      const errors = buildResult.diagnostics.filter(d => {
+        try { return JSON.parse(d).level === 'error'; } catch { return true; }
+      });
+      assert.deepEqual(errors, [], `${displayName}: no compilation errors`);
+      const linkResult = await linkCore(worker, buildResult.core);
+      const output = runCompiledJs(linkResult.result);
+      const expected = EXPECTED_OUTPUTS[displayName];
+      if (expected) {
+        assert.ok(output.includes(expected), `${displayName}: output should contain "${expected}"`);
+      }
+    } finally {
+      worker.terminate();
+    }
+  });
+}


### PR DESCRIPTION
Closes #24

## Summary

Decomposes the inline `SAMPLE_CODES` in `app.tsx` into individual `.mbt` files under `src/sample_codes/`, adds a new **Comprehensive Demo** sample, and adds compile+run tests for all samples.

## Changes

### New: `src/sample_codes/`
Sample codes are now maintained as individual MoonBit files:
- `01_hello.mbt` → "Hello"
- `02_multiple_files.mbt` → "Multiple Files"
- `03_with_package_import.mbt` → "With Package Import" (also fixes deprecated `size()` → `length()`)
- `04_comprehensive_demo.mbt` → **New** "Comprehensive Demo" — showcases enums, traits, generics, pattern matching, error handling, loop expressions, string views, and more

### Updated: `src/app.tsx`
Replaces inline `SAMPLE_CODES` with Vite's `import.meta.glob('./sample_codes/*.mbt', { as: 'raw', eager: true })`. Files are loaded at build time; display names are automatically derived from filenames (`01_hello.mbt` → `"Hello"`).

### Updated: `test/compiler-node.test.mjs`
Adds compile+run tests for every file in `src/sample_codes/` using `fs.readdirSync`. Each sample is tested for:
- Compiles without errors
- Runs and produces expected output

**All 17 tests pass.**